### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.8.3-beta] - Sept 11, 2024
+- SharedData.ClearData is now Obsolete and will be removed in a future release. Use SharedData.ClearAllData instead.
+- Added SharedData.ClearAllData method to clear all shared data.
+- Added SharedData.RemoveData(string key) method to remove a specific key from the shared data.
+- Added SharedData.GetKeys() method to return all keys in the shared data.
+
 ## [0.8.2-beta] - Sept 09, 2024
 - Added TryGetData and HasData methods to the SharedData class
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "com.nonatomic.visualstatemachinev2",
-  "version": "0.8.2-beta",
+  "version": "0.8.3-beta",
   "displayName": "Visual State Machine V2",
   "description": "Visual State Machine V2",
   "unity": "2022.3",


### PR DESCRIPTION
## [0.8.3-beta] - Sept 11, 2024
- SharedData.ClearData is now Obsolete and will be removed in a future release. Use SharedData.ClearAllData instead.
- Added SharedData.ClearAllData method to clear all shared data.
- Added SharedData.RemoveData(string key) method to remove a specific key from the shared data.
- Added SharedData.GetKeys() method to return all keys in the shared data.