### PR TITLE
Feat/model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [0.10.2-beta] - Feb 11, 2025
+- Fix for playing selected StateMachineControllers model in the State Machine Editor when entering runtime.
+  - Previously required a deselect and reselect of the StateMachineController to play the model in the State Machine Editor.
+
 # [0.10.2-beta] - Feb 05, 2025
 - Fix for lack of stacktrace in exceptions thrown by states
 

--- a/Editor/StateGraph/Nodes/BaseStateNodeView.cs
+++ b/Editor/StateGraph/Nodes/BaseStateNodeView.cs
@@ -17,7 +17,6 @@ using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.UIElements;
-using Debug = UnityEngine.Debug;
 
 namespace Nonatomic.VSM2.Editor.StateGraph.Nodes
 {
@@ -136,11 +135,12 @@ namespace Nonatomic.VSM2.Editor.StateGraph.Nodes
 		{
 			var position = NodeModel.Position;
 			
-			var rect = this.GetPosition();
+			var rect = GetPosition();
 			rect.position = position;
 			
 			SetPosition(rect);
 			
+			if(StateMachineModel == null) return;
 			EditorUtility.SetDirty(StateMachineModel);
 			EditorApplication.delayCall += () => AssetDatabase.SaveAssets();
 		}
@@ -403,6 +403,9 @@ namespace Nonatomic.VSM2.Editor.StateGraph.Nodes
 		
 		protected virtual void AddProperties(VisualElement container)
 		{
+			if (NodeModel == null) return;
+			if (NodeModel.State == null) return;
+			
 			var scrollView = new ScrollView();
 			container.Add(scrollView);
 

--- a/Editor/StateGraph/StateNodeGraphStateManager.cs
+++ b/Editor/StateGraph/StateNodeGraphStateManager.cs
@@ -14,22 +14,29 @@ namespace Nonatomic.VSM2.Editor.StateGraph
 		
 		public StateNodeGraphStateManager(string id) : base(id)
 		{
-			
+			// ...
 		}
 
 		public void LoadModelFromStateController()
 		{
-			if (string.IsNullOrEmpty(StateControllerId)) return;
-			
+			// Look for the controller that matches the stored ID.
 			var stateMachines = GameObject.FindObjectsByType<StateMachineController>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
-			var stateMachineController = stateMachines.FirstOrDefault(smc => smc.Id == StateControllerId);
-			if (!stateMachineController) return;
-
-			SetModel(stateMachineController.Model);
+			var controller = stateMachines.FirstOrDefault(smc => smc.Id == StateControllerId);
+			
+			if (controller)
+			{
+				SetModel(controller.Model);
+			}
+			else
+			{
+				Debug.LogWarning($"StateMachineController with ID {StateControllerId} not found.");
+			}
 		}
 		
 		public void SetStateControllerId(string id)
 		{
+			if (string.IsNullOrEmpty(id)) return;
+			
 			StateControllerId = id;
 			SaveState();
 		}
@@ -43,16 +50,14 @@ namespace Nonatomic.VSM2.Editor.StateGraph
 		public override void LoadState()
 		{
 			base.LoadState();
-			
 			StateControllerId = EditorPrefs.GetString(GetKey(StateMachineControllerIdKey));
 		}
 
 		public override void SaveState()
 		{
 			base.SaveState();
-			
 			if (!Model) return;
-
+		
 			EditorPrefs.SetString(GetKey(StateMachineControllerIdKey), StateControllerId);
 		}
 	}

--- a/Editor/StateGraph/VisualElements/StateGraphView.cs
+++ b/Editor/StateGraph/VisualElements/StateGraphView.cs
@@ -221,16 +221,8 @@ namespace Nonatomic.VSM2.Editor.StateGraph
 			var stateManager = (StateNodeGraphStateManager) StateManager;
 			var gridPos = stateManager.GridPosition;
 			
-			switch (stateChange)
-			{
-				case PlayModeStateChange.EnteredPlayMode:
-				case PlayModeStateChange.EnteredEditMode:
-				case PlayModeStateChange.ExitingEditMode:
-				case PlayModeStateChange.ExitingPlayMode:
-					stateManager.LoadModelFromStateController();
-					PopulateGraph(StateManager.Model, recentre: true);
-					break;
-			}
+			stateManager.LoadModelFromStateController();
+			PopulateGraph(StateManager.Model, recentre: true);
 			
 			EditorApplication.delayCall += ()=>
 			{

--- a/Runtime/StateGraph/StateMachineController.cs
+++ b/Runtime/StateGraph/StateMachineController.cs
@@ -148,5 +148,10 @@ namespace Nonatomic.VSM2.StateGraph
 			if(!_model) return;
 			_stateMachine = new StateMachine(_model, this);
 		}
+		
+		private void OnValidate()
+		{
+			CreateUniqueId();
+		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "com.nonatomic.visualstatemachinev2",
-  "version": "0.10.2-beta",
+  "version": "0.10.3-beta",
   "displayName": "Visual State Machine V2",
   "description": "Visual State Machine V2\n\nIMPORTANT NOTE: If you are upgrading to 0.9.0-beta and above from earlier versions, note that `OnEnter` methods now require an `[Enter]` attribute and that the base `OnEnter` method is no longer abstract but virtual.",
   "unity": "2022.3",


### PR DESCRIPTION
- Fix for playing selected StateMachineControllers model in the State Machine Editor when entering runtime.
  - Previously required a deselect and reselect of the StateMachineController to play the model in the State Machine Editor.